### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is the **CatoCLI** (`catocli`) codebase — a Python CLI tool for the Cato Networks GraphQL API. It is a single-package Python project (not a monorepo). There are no local services, databases, or containers to run. The CLI communicates with the external Cato Networks API at `api.catonetworks.com`.
+
+### Running the CLI
+
+After `pip install -e .`, the `catocli` command is available. Use `catocli -h` for help.
+
+### Testing
+
+Run validation tests (no API credentials required):
+
+```
+pytest tests/run_all_tests.py -v
+```
+
+Run the full test runner (generated + custom tests require API credentials):
+
+```
+python3 tests/run_all_tests.py --skip-generated --skip-custom
+```
+
+To run generated/custom tests that hit the actual Cato API, configure credentials first:
+
+```
+catocli configure set --cato-token "TOKEN" --account-id "ACCOUNT_ID" --skip-validation
+```
+
+### Important notes
+
+- **PATH**: pytest and other pip-installed scripts are in `/home/ubuntu/.local/bin` — ensure it's on PATH (`export PATH="/home/ubuntu/.local/bin:$PATH"`).
+- **Test from project root**: Always run `pytest` from `/workspace` (the repo root). Running `run_all_tests.py` from inside `tests/` can cause path resolution differences.
+- **No linter configured**: The repo has no configured linter (no flake8, pylint, ruff, or similar config). Python type checking and linting are not part of the project's CI workflow.
+- **Local operations**: `catocli query appCategory` works without API credentials (it's a local lookup). Use it to verify the CLI is functional without needing a Cato account.
+- **Pre-existing test quirk**: The `test_invalid_json_handling` test may fail when run via `run_all_tests.py` from the `tests/` directory (due to credential check short-circuiting the JSON validation path). It passes when run via `pytest` from the project root.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on the catocli codebase.

## Changes

- **AGENTS.md**: New file with cloud-specific development instructions including:
  - Overview of the project (Python CLI, no local services needed)
  - How to run the CLI and tests
  - Important PATH and directory notes
  - Known test quirks and local operations that work without API credentials

## Testing

All 22 validation tests pass:
```
pytest tests/run_all_tests.py -v
# 22 passed in ~109s
```

The CLI runs correctly:
```
catocli --version  # 3.0.69
catocli query appCategory '{"names": ["storage"]}'  # Returns results locally
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2593c92d-a3c4-4a72-abbf-202918f3e6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2593c92d-a3c4-4a72-abbf-202918f3e6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

